### PR TITLE
A few more device selector fixes

### DIFF
--- a/src/labelle/cli/cli.py
+++ b/src/labelle/cli/cli.py
@@ -202,8 +202,11 @@ def parse_args():
     )
     parser.add_argument(
         "--device",
-        nargs="+",
-        help="Device pattern to match",
+        action="append",
+        help=(
+            "Select a particular device by filtering for a given substring "
+            "in the device's manufacturer, product or serial number."
+        ),
         type=str,
     )
     return parser.parse_args()

--- a/src/labelle/gui/q_device_selector.py
+++ b/src/labelle/gui/q_device_selector.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import logging
-from typing import Optional
 
 from PyQt6 import QtCore
 from PyQt6.QtWidgets import (
@@ -88,7 +89,7 @@ class QDeviceSelector(QToolBar):
         self._action_error_label = self.addWidget(self._error_label)
 
     @property
-    def selected_device(self) -> Optional[UsbDevice]:
+    def selected_device(self) -> UsbDevice | None:
         device = None
         if self._devices.currentIndex() >= 0:
             device = self.device_manager.devices[self._devices.currentIndex()]

--- a/src/labelle/gui/q_settings_toolbar.py
+++ b/src/labelle/gui/q_settings_toolbar.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import logging
 from dataclasses import dataclass
-from typing import Optional
 
 from PyQt6 import QtCore
 from PyQt6.QtWidgets import QCheckBox, QComboBox, QLabel, QSpinBox, QToolBar, QWidget
@@ -30,7 +31,7 @@ class Settings:
 class QSettingsToolbar(QToolBar):
     settings_changed_signal = QtCore.pyqtSignal(Settings, name="settingsChangedSignal")
 
-    def __init__(self, parent: Optional[QWidget] = None):
+    def __init__(self, parent: QWidget | None = None):
         super().__init__(parent)
         self._background_color = QComboBox()
         self._foreground_color = QComboBox()

--- a/src/labelle/lib/devices/online_device_manager.py
+++ b/src/labelle/lib/devices/online_device_manager.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 import logging
-from typing import Optional
 
 from PyQt6 import QtCore
 from PyQt6.QtCore import QTimer
@@ -14,7 +15,7 @@ POSSIBLE_USB_ERRORS = (NoBackendError, USBError)
 
 
 class OnlineDeviceManager(QWidget):
-    _last_scan_error: Optional[DeviceManagerError]
+    _last_scan_error: DeviceManagerError | None
     _status_time: QTimer
     _device_manager: DeviceManager
     last_scan_error_changed_signal = QtCore.pyqtSignal(
@@ -49,7 +50,7 @@ class OnlineDeviceManager(QWidget):
         self._refresh_devices()
 
     @property
-    def last_scan_error(self) -> Optional[DeviceManagerError]:
+    def last_scan_error(self) -> DeviceManagerError | None:
         return self._last_scan_error
 
     @property


### PR DESCRIPTION
We aren't testing the GUI in the automated tests, and I discovered it was failing to load on Python 3.8 due to missing future annotations. Ideally this stuff is caught by tests, but I've never done a GUI before, so I don't know offhand how to test a GUI from GitHub CI.

Next, having a greedy `--device` argument was conflicting with the greedy `text` argument. I changed it so that you add multiple filters via multiple `--device` arguments.

Does it make sense to be matching on the manufacturer? I'm inclined to just check product description and serial number.

Finally, I'm not sure offhand how to solve this, but let's say I have multiple devices and I want to determine a filter string. Currently the only way I can see to do this is to print a label and include `--verbose`, which I find pretty unintuitive. Perhaps we need something like `--list-devices`, but I feel like our arguments are getting fairly bloated.