### PR TITLE
Don't assume the default barcode type when handling empty string

### DIFF
--- a/src/labelle/lib/render_engines/barcode.py
+++ b/src/labelle/lib/render_engines/barcode.py
@@ -4,12 +4,22 @@ import barcode as barcode_module
 from PIL import Image
 
 from labelle.lib.barcode_writer import BarcodeImageWriter
-from labelle.lib.constants import DEFAULT_BARCODE_TYPE
+from labelle.lib.constants import DEFAULT_BARCODE_TYPE, BarcodeType
 from labelle.lib.render_engines.render_context import RenderContext
 from labelle.lib.render_engines.render_engine import (
     RenderEngine,
     RenderEngineException,
 )
+
+if DEFAULT_BARCODE_TYPE != BarcodeType.CODE128:
+    # Ensure that we fail fast if the default barcode type is adjusted
+    # and the code below hasn't been updated.
+    raise RuntimeError(
+        "The conditional below assumes that the default barcode type is CODE128. "
+        "Different barcodes have different quirks, so we should manually test the "
+        "new default to ensure a good user experience in the GUI when the initial "
+        "value is an empty string."
+    )
 
 
 class BarcodeRenderError(RenderEngineException):
@@ -25,7 +35,10 @@ class BarcodeRenderEngine(RenderEngine):
         self.barcode_type = barcode_type or DEFAULT_BARCODE_TYPE
 
     def render(self, context: RenderContext) -> Image.Image:
-        if self.barcode_type == "code128" and self.content == "":
+        if (
+            self.barcode_type == DEFAULT_BARCODE_TYPE == BarcodeType.CODE128
+            and self.content == ""
+        ):
             # An exception is raised on the empty string. Since this is
             # the default code, we really don't want to trigger a popup
             # in the GUI before the user entered a barcode.


### PR DESCRIPTION
Addresses <https://github.com/labelle-org/labelle/pull/23#discussion_r1581920270>

The idea here is that we should be able to adjust the default barcode without introducing any surprise errors. Since different barcodes have different edge cases, changing the default barcode will require manual testing and adjustment. Therefore, I build in an exception with an explanatory message in order to ensure that the proper adjustments will be made during the development process.