### PR TITLE
Enable listing of devices without list-devices subcommand

### DIFF
--- a/src/labelle/cli/cli.py
+++ b/src/labelle/cli/cli.py
@@ -88,10 +88,6 @@ def get_device_manager() -> DeviceManager:
     return device_manager
 
 
-app = typer.Typer()
-
-
-@app.command(hidden=True)
 def list_devices() -> NoReturn:
     device_manager = get_device_manager()
     console = Console()
@@ -103,6 +99,9 @@ def list_devices() -> NoReturn:
         )
     console.print(table)
     raise typer.Exit()
+
+
+app = typer.Typer()
 
 
 @app.callback(invoke_without_command=True)
@@ -123,7 +122,8 @@ def default(
             "--device",
             help=(
                 "Select a particular device by filtering for a given substring "
-                "in the device's manufacturer, product or serial number"
+                "in the device's manufacturer, product or serial number. "
+                'Use "--device list" to list all available devices.'
             ),
             rich_help_panel="Device Configuration",
         ),
@@ -377,6 +377,9 @@ def default(
     if (not verbose) and (not is_verbose_env_vars()):
         # Neither --verbose flag nor the environment variable is set.
         set_not_verbose()
+
+    if device_pattern == ["list"]:
+        list_devices()
 
     # Raise informative errors with old dymoprint arguments
     if preview:


### PR DESCRIPTION
In terms of keeping the CLI simple, I think avoiding subcommands may be a worthy goal. I find it really elegant when `labelle --help` prints a complete summary without needing to explore a tree of help of subcommands.

Thus I'm offering this alternative proposal. Introducing a special `--device list` case. It's a bit of a hack, but I think it's a very practical hack: nobody will ever want to filter by the string `"list"`. Also, when the user is trying to figure out what they can filter on, they'll be reading the annotation for `--device`, and the info is provided there.

It seems to me like this sacrifices some mildly ugly code to provide a more focused user interface. Thoughts?