### PR TITLE
Add a test to ensure that the GUI module is importable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
+        sudo apt-get install -y libegl1
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
     - name: Test with tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ commands =
   pip freeze
   labelle --version
   labelle --help
+  python -c "import labelle.gui.gui; print('GUI import succeeded')"
   labelle --output console "single line"
   labelle --output console_inverted "inverted"
   labelle --output console multiple lines


### PR DESCRIPTION
This is an extremely basic check to catch errors like using incompatible language features in GUI code which isn't imported by the CLI. This is a temporary measure until we implement #24.