### PR TITLE
Fix --output=console-inverted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ commands =
   labelle --help
   python -c "import labelle.gui.gui; print('GUI import succeeded')"
   labelle --output console "single line"
-  labelle --output console_inverted "inverted"
+  labelle --output console-inverted "inverted"
   labelle --output console multiple lines
   labelle --output console --barcode "Barcode" --barcode-type code128
   labelle --output console --barcode-with-text "Barcode" --barcode-type code128 Caption

--- a/src/labelle/lib/constants.py
+++ b/src/labelle/lib/constants.py
@@ -107,6 +107,6 @@ class Direction(str, Enum):
 class Output(str, Enum):
     PRINTER = "printer"
     CONSOLE = "console"
-    CONSOLE_INVERTED = "console_inverted"
+    CONSOLE_INVERTED = "console-inverted"
     BROWSER = "browser"
     IMAGEMAGICK = "imagemagick"


### PR DESCRIPTION
As a CLI option, a dash is more natural than an underscore.