### PR TITLE
GUI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,8 @@ jobs:
         os : [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
-
+    env:
+      DISPLAY: ':99.0'
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
@@ -22,7 +23,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        sudo apt-get install -y libegl1
+        sudo apt-get install -y libegl1 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1 libdbus-1-3 libxcb-cursor0
+        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
     - name: Test with tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,9 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os : [ubuntu-latest]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
       fail-fast: false
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,9 @@ requires-python = ">=3.8,<4"
 [project.optional-dependencies]
 test = [
     "pytest-cov",
-    "pytest-image-diff"
+    "pytest-image-diff",
+    "pytest-qt",
+    "pytest-xvfb",
 ]
 
 [project.urls]

--- a/src/labelle/gui/tests/test_gui.py
+++ b/src/labelle/gui/tests/test_gui.py
@@ -1,0 +1,22 @@
+from labelle.gui.gui import LabelleWindow
+from labelle.gui.q_label_widgets import (
+    TextDymoLabelWidget,
+)
+
+
+def test_main_window(qtbot):
+    widget = LabelleWindow()
+    qtbot.addWidget(widget)
+
+    assert not widget._actions.isEnabled()
+    assert widget._device_selector.isEnabled()
+    assert not widget._label_list.isEnabled()
+    assert not widget._render_widget.isEnabled()
+    assert not widget._render.isEnabled()
+    assert not widget._settings_toolbar.isEnabled()
+    assert widget._device_selector._error_label.text() == "No supported devices found"
+    assert not widget._actions._print_button.isEnabled()
+    assert widget._label_list.count() == 1
+    item = widget._label_list.itemWidget(widget._label_list.item(0))
+    assert isinstance(item, TextDymoLabelWidget)
+    assert item.label.toPlainText() == "text"


### PR DESCRIPTION
The GUI is rather useless when the app is being run in the test environment, as there are no printers connected (there is no USB backend at all).
This simple test verifies the most basic existence of selected widget, and their content.
We will need to figure out how to test the app with a state that resembles actual printer. We might need to introduce test mode, in which all supported printers are shown in the device selector, so we can test various features for each.