### PR TITLE
GUI: Add font preview to selection combobox

### DIFF
--- a/src/labelle/gui/q_label_widgets.py
+++ b/src/labelle/gui/q_label_widgets.py
@@ -47,15 +47,13 @@ class FontStyle(QComboBox):
 
         # Populate font_style
         fonts_model = QStandardItemModel()
+
+        # Create items for all available fonts
         for font_path in get_available_fonts():
             # Create item for font
             item = self.make_combobox_item_for_font(font_path)
-
-            if item is None:
-                continue
-
-            # Append to data model
-            fonts_model.appendRow(item)
+            if item is not None:
+                fonts_model.appendRow(item)
 
         self.setModel(fonts_model)
 

--- a/src/labelle/gui/q_label_widgets.py
+++ b/src/labelle/gui/q_label_widgets.py
@@ -1,5 +1,6 @@
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Optional
 
 from PyQt6 import QtCore
 from PyQt6.QtGui import (
@@ -122,7 +123,7 @@ class BaseLabelWidget(QWidget):
         pass
 
     @property
-    def render_engine(self) -> Optional[RenderEngine]:
+    def render_engine(self) -> RenderEngine | None:
         try:
             return self.render_engine_impl
         except RenderEngineException as err:
@@ -156,7 +157,7 @@ class TextDymoLabelWidget(BaseLabelWidget):
     font_size: QSpinBox
     frame_width_px: QSpinBox
 
-    def __init__(self, render_context: RenderContext, parent: Optional[QWidget] = None):
+    def __init__(self, render_context: RenderContext, parent: QWidget | None = None):
         super().__init__(parent)
         self.render_context = render_context
 

--- a/src/labelle/gui/q_label_widgets.py
+++ b/src/labelle/gui/q_label_widgets.py
@@ -2,7 +2,13 @@ from pathlib import Path
 from typing import Optional
 
 from PyQt6 import QtCore
-from PyQt6.QtGui import QIcon
+from PyQt6.QtGui import (
+    QFont,
+    QFontDatabase,
+    QIcon,
+    QStandardItem,
+    QStandardItemModel,
+)
 from PyQt6.QtWidgets import (
     QCheckBox,
     QComboBox,
@@ -38,12 +44,46 @@ from labelle.lib.render_engines.render_engine import RenderEngineException
 class FontStyle(QComboBox):
     def __init__(self) -> None:
         super().__init__()
+
         # Populate font_style
+        fonts_model = QStandardItemModel()
         for font_path in get_available_fonts():
-            name = font_path.stem
-            absolute_path = font_path.absolute()
-            self.addItem(name, absolute_path)
+            # Retrieve font options
+            font_name = font_path.stem
+            font_absolute_path = font_path.absolute()
+
+            # Make combobox item
+            item = QStandardItem(font_name)
+            item.setData(font_absolute_path, QtCore.Qt.ItemDataRole.UserRole)
+
+            # Add application font to allow Qt rendering with it
+            try:
+                font_id = QFontDatabase.addApplicationFont(str(font_absolute_path))
+                loaded_font_families = QFontDatabase.applicationFontFamilies(font_id)
+                if loaded_font_families:
+                    item_font = QFont(loaded_font_families[0])
+
+                    if "bold" in font_name.lower():
+                        item_font.setBold(True)
+
+                    if "italic" in font_name.lower():
+                        item_font.setItalic(True)
+
+                    item.setFont(item_font)
+            except:
+                pass
+                # Failed loading font
+
+            # Append to data model
+            fonts_model.appendRow(item)
+
+        self.setModel(fonts_model)
+
+        try:
             self.setCurrentText("Carlito-Regular")
+        except:
+            pass
+            # Failed setting default font
 
 
 class BaseLabelWidget(QWidget):

--- a/src/labelle/gui/q_label_widgets.py
+++ b/src/labelle/gui/q_label_widgets.py
@@ -48,42 +48,49 @@ class FontStyle(QComboBox):
         # Populate font_style
         fonts_model = QStandardItemModel()
         for font_path in get_available_fonts():
-            # Retrieve font options
-            font_name = font_path.stem
-            font_absolute_path = font_path.absolute()
+            # Create item for font
+            item = self.make_combobox_item_for_font(font_path)
 
-            # Make combobox item
-            item = QStandardItem(font_name)
-            item.setData(font_absolute_path, QtCore.Qt.ItemDataRole.UserRole)
-
-            # Add application font to allow Qt rendering with it
-            try:
-                font_id = QFontDatabase.addApplicationFont(str(font_absolute_path))
-                loaded_font_families = QFontDatabase.applicationFontFamilies(font_id)
-                if loaded_font_families:
-                    item_font = QFont(loaded_font_families[0])
-
-                    if "bold" in font_name.lower():
-                        item_font.setBold(True)
-
-                    if "italic" in font_name.lower():
-                        item_font.setItalic(True)
-
-                    item.setFont(item_font)
-            except:
-                pass
-                # Failed loading font
+            if item is None:
+                continue
 
             # Append to data model
             fonts_model.appendRow(item)
 
         self.setModel(fonts_model)
 
-        try:
-            self.setCurrentText("Carlito-Regular")
-        except:
-            pass
-            # Failed setting default font
+        # Select default font
+        self.setCurrentText("Carlito-Regular")
+
+    def make_combobox_item_for_font(self, font_path: Path) -> QStandardItem | None:
+        # Retrieve font data
+        font_name = font_path.stem
+        font_absolute_path = font_path.absolute()
+
+        # Make combobox item
+        item = QStandardItem(font_name)
+        item.setData(font_absolute_path, QtCore.Qt.ItemDataRole.UserRole)
+        item_font = QFont()
+
+        # Add application font to allow Qt rendering with it
+        font_id = QFontDatabase.addApplicationFont(str(font_absolute_path))
+        if font_id >= 0:
+            loaded_font_families = QFontDatabase.applicationFontFamilies(font_id)
+            if loaded_font_families:
+                item_font.setFamilies(loaded_font_families)
+
+        # Set bold if font name indictates it
+        if "bold" in font_name.lower():
+            item_font.setBold(True)
+
+        # Set italic if font name indictates it
+        if "italic" in font_name.lower():
+            item_font.setItalic(True)
+
+        # font to item
+        item.setFont(item_font)
+
+        return item
 
 
 class BaseLabelWidget(QWidget):

--- a/src/labelle/gui/q_label_widgets.py
+++ b/src/labelle/gui/q_label_widgets.py
@@ -53,15 +53,14 @@ class FontStyle(QComboBox):
         for font_path in get_available_fonts():
             # Create item for font
             item = self.make_combobox_item_for_font(font_path)
-            if item is not None:
-                fonts_model.appendRow(item)
+            fonts_model.appendRow(item)
 
         self.setModel(fonts_model)
 
         # Select default font
         self.setCurrentText("Carlito-Regular")
 
-    def make_combobox_item_for_font(self, font_path: Path) -> QStandardItem | None:
+    def make_combobox_item_for_font(self, font_path: Path) -> QStandardItem:
         # Retrieve font data
         font_name = font_path.stem
         font_absolute_path = font_path.absolute()


### PR DESCRIPTION
Just a tiny thing I cooked up today. 
When selecting a font I got a big list of names, but no clue what they looked like.

This PR changes the combo-box so that every font name is shown in the font itself.
Because we don´t rely on system fonts but use our own font directory the handling is a bit "custom" instead of using a standard font selection combo-box.
But for this purpose I think it works very well.

Picture:
![image](https://github.com/labelle-org/labelle/assets/5355001/4bcf92b4-f997-43c1-a6f4-9a5965957410)

Please advise how to handle the empty excerpt error. 
I added them because the font handling may fail. But it it is not important at all. Just ignore it.
Same with selecting the default font, that might not be available if the user removes it.
