### PR TITLE
Enable "unsafe" ruff fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,7 +23,7 @@ repos:
   rev: v0.4.8
   hooks:
   - id: ruff
-    args: [--fix, --exit-non-zero-on-fix]
+    args: [--fix, --unsafe-fixes, --exit-non-zero-on-fix]
   - id: ruff-format
 
 - repo: https://gitlab.com/bmares/check-json5


### PR DESCRIPTION
Ruff's "unsafe" fixes are still quite safe. (It's mainly "unsafe" if you have a really huge codebase that wasn't previously linted.)

This should help to ease some of the friction in instances like https://github.com/labelle-org/labelle/pull/56.