### PR TITLE
Fix Frequent overflow issues #68 on LabelManager 280

### DIFF
--- a/src/labelle/lib/devices/dymo_labeler.py
+++ b/src/labelle/lib/devices/dymo_labeler.py
@@ -98,7 +98,10 @@ class DymoLabelerFunctions:
                 # Send a status request
                 cmdBin = array.array("B", [ESC, ord("A")])
                 cmdBin.tofile(self._devout)
-                rspBin = self._devin.read(8)
+                # Increase buffer size to 16 bytes to prevent overflow
+                # on LabelManager 280
+                # https://libusb.sourceforge.io/api-1.0/libusb_packetoverflow.html
+                rspBin = self._devin.read(16)
                 _ = array.array("B", rspBin).tolist()
                 # Ok, we got a response. Now we can send a chunk of data
 
@@ -129,7 +132,7 @@ class DymoLabelerFunctions:
         if not self._response:
             return None
         self._response = False
-        responseBin = self._devin.read(8)
+        responseBin = self._devin.read(16)
         response = array.array("B", responseBin).tolist()
         return response
 

--- a/src/labelle/lib/devices/dymo_labeler.py
+++ b/src/labelle/lib/devices/dymo_labeler.py
@@ -98,10 +98,7 @@ class DymoLabelerFunctions:
                 # Send a status request
                 cmdBin = array.array("B", [ESC, ord("A")])
                 cmdBin.tofile(self._devout)
-                # Increase buffer size to 16 bytes to prevent overflow
-                # on LabelManager 280
-                # https://libusb.sourceforge.io/api-1.0/libusb_packetoverflow.html
-                rspBin = self._devin.read(16)
+                rspBin = self._devin.read(512)
                 _ = array.array("B", rspBin).tolist()
                 # Ok, we got a response. Now we can send a chunk of data
 
@@ -132,7 +129,7 @@ class DymoLabelerFunctions:
         if not self._response:
             return None
         self._response = False
-        responseBin = self._devin.read(16)
+        responseBin = self._devin.read(512)
         response = array.array("B", responseBin).tolist()
         return response
 


### PR DESCRIPTION
The overflow happens because the LabelManager 280 sends more than 8 bytes and the buffer is too small. This needs testing on other devices, but I expect that it'll be fine for them too.

LibUSB has no way of knowing how much data the device is going to send so if the supplied buffer size is too small, the overflow happens.

See https://libusb.sourceforge.io/api-1.0/libusb_packetoverflow.html for more info