### PR TITLE
Fix --fixed-length Flag Doesn't Work Alone

### DIFF
--- a/src/labelle/cli/cli.py
+++ b/src/labelle/cli/cli.py
@@ -444,8 +444,7 @@ def default(
             "Cannot specify both barcode with text and regular barcode"
         )
 
-    if fixed_length is not None and (
-        not (min_length is None or min_length == 0) or max_length is not None
+    if fixed_length is not None and min_length is not None max_length is not None
     ):
         raise typer.BadParameter(
             "Cannot specify min/max and fixed length at the same time"

--- a/src/labelle/cli/cli.py
+++ b/src/labelle/cli/cli.py
@@ -444,8 +444,7 @@ def default(
             "Cannot specify both barcode with text and regular barcode"
         )
 
-    if fixed_length is not None and min_length is not None max_length is not None
-    ):
+    if fixed_length is not None and min_length is not None max_length is not None):
         raise typer.BadParameter(
             "Cannot specify min/max and fixed length at the same time"
         )

--- a/src/labelle/cli/cli.py
+++ b/src/labelle/cli/cli.py
@@ -444,7 +444,9 @@ def default(
             "Cannot specify both barcode with text and regular barcode"
         )
 
-    if fixed_length is not None and (min_length != 0 or max_length is not None):
+    if fixed_length is not None and (
+        not (min_length is None or min_length == 0) or max_length is not None
+    ):
         raise typer.BadParameter(
             "Cannot specify min/max and fixed length at the same time"
         )

--- a/src/labelle/cli/cli.py
+++ b/src/labelle/cli/cli.py
@@ -444,7 +444,7 @@ def default(
             "Cannot specify both barcode with text and regular barcode"
         )
 
-    if fixed_length is not None and min_length is not None max_length is not None):
+    if fixed_length is not None and (min_length is not None or max_length is not None):
         raise typer.BadParameter(
             "Cannot specify min/max and fixed length at the same time"
         )


### PR DESCRIPTION
Fixes https://github.com/labelle-org/labelle/issues/78

Using the --fixed-length flag currently yields the following error:

```$ python3 -m labelle.cli.cli --fixed-length 100 --justify center "CLAMPS"                                                           
Usage: python -m labelle.cli.cli [OPTIONS] [TEXT]... COMMAND [ARGS]...
Try 'python -m labelle.cli.cli --help' for help.
╭─ Error ──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Invalid value: Cannot specify min/max and fixed length at the same time                                                                                                                                      │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```

This PR allows the --min-length flag to be 0 or None