### PR TITLE
Support for LabelManager Wireless PnP

### DIFF
--- a/src/labelle/lib/devices/dymo_labeler.py
+++ b/src/labelle/lib/devices/dymo_labeler.py
@@ -222,6 +222,8 @@ class DymoLabelerFunctions:
             self._raw_print_label(lines[0 : self._maxLines])
             del lines[0 : self._maxLines]
         self._raw_print_label(lines)
+        self._cut()
+        self._send_command()
 
     def _raw_print_label(self, lines: list[list[int]]):
         """Print the label described by lines (HLF)."""
@@ -240,7 +242,7 @@ class DymoLabeler:
 
     LABELER_DISTANCE_BETWEEN_PRINT_HEAD_AND_CUTTER_MM = 8.1
     LABELER_PRINT_HEAD_HEIGHT_MM = 8.2
-    SUPPORTED_TAPE_SIZES_MM = (19, 12, 9, 6)
+    SUPPORTED_TAPE_SIZES_MM = (24, 19, 12, 9, 6)
     DEFAULT_TAPE_SIZE_MM = 12
 
     def __init__(


### PR DESCRIPTION
Some initial work on LabelManager Wireless PnP

- add auto cut to end of print statement (this is added to every print - in testing with a LabelManager PnP this doesn't effect anything
- add 24mm to valid lines

still to do:

- printer doesn't output anything when cold-booted until it has been printed to once by another application - currently i'm using [dymoconf/render-label.py](https://github.com/simon-budig/dymoconf/blob/master/render-label.py) and sending it to port 9100 on the printer to do this initialization
- when things are printed out, they come out very squished - i *suspect* i need to fiddle with `LABELER_PRINT_HEAD_HEIGHT_MM` depending on the specific labeller but i could be wrong here - i can't find any codepaths that differ between devices at the moment