### PR TITLE
Fix broken links in PyPI README

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [build-system]
-requires = ["hatchling >=1.11.1,<2.0.0", "hatch-vcs >=0.3.0,<0.4"]
+requires = ["hatchling >=1.11.1,<2.0.0", "hatch-vcs >=0.3.0,<0.4", "hatch-fancy-pypi-readme"]
 build-backend = "hatchling.build"
 
 [project]
 name = "labelle"
 description = "Open-source label printing software"
-readme = "README.md"
 url = "https://github.com/labelle-org/labelle"
 authors = [{name = "Sebastian J. Bronner", email = "waschtl@sbronner.com"}]
 maintainers = [
@@ -35,7 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Printing",
 ]
-dynamic = ["version"]
+dynamic = ["version", "readme"]
 requires-python = ">=3.8,<4"
 
 [project.optional-dependencies]
@@ -65,6 +64,30 @@ version-file = "src/labelle/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/labelle"]
+
+# <https://github.com/hynek/hatch-fancy-pypi-readme>
+[tool.hatch.metadata.hooks.fancy-pypi-readme]
+content-type = "text/markdown"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.fragments]]
+path = "README.md"
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+# Image links should go to the raw content on GitHub
+# <https://stackoverflow.com/a/46875147>
+pattern = '\[(.*?)\]\(((?!https?://)\S+\.(png|jpe?g|svg|gif))\)'
+replacement = '[\1](https://raw.githubusercontent.com/labelle-org/labelle/main/\g<2>)'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+# Handle also HTML image tags
+pattern = '''(<img\b[^>]*\bsrc=)(['"])((?!https?://)[^'"]+)(['"][^>]*>)'''
+replacement = '<img src="https://raw.githubusercontent.com/labelle-org/labelle/main/\g<3>\g<4>'
+
+[[tool.hatch.metadata.hooks.fancy-pypi-readme.substitutions]]
+# Remaining non-image relative links map to the normal absolute GitHub URL
+# <https://stackoverflow.com/a/46875147>
+pattern = '\[(.*?)\]\(((?!https?://)\S+)\)'
+replacement = '[\1](https://github.com/labelle-org/labelle/tree/main/\g<2>)'
 
 [tool.tox]
 legacy_tox_ini = """


### PR DESCRIPTION
I noticed that the images on PyPI are broken, so this is basically just a copy-paste from https://github.com/pymc-labs/pymc-marketing/pull/1051.

Use the `hatch-fancy-pypi-readme` plugin to fix broken links on PyPI.

To view differences, run

```bash
pipx run hatch-fancy-pypi-readme > pypi-readme.md
diff README.md pypi-readme.md
```

Result:

```diff
10c10
<   <img src="labelle.png" alt="logo" width="400"></img>
---
>   <img src="https://raw.githubusercontent.com/labelle-org/labelle/main/labelle.png" alt="logo" width="400"></img>
44c44
< Labelle is not affiliated with DYMO. Please see the [disclaimer](#disclaimers) below.
---
> Labelle is not affiliated with DYMO. Please see the [disclaimer](https://github.com/labelle-org/labelle/tree/main/#disclaimers) below.
50c50
< [adding the device id](src/labelle/lib/constants.py). Once you can print,
---
> [adding the device id](https://github.com/labelle-org/labelle/tree/main/src/labelle/lib/constants.py). Once you can print,
52c52
< by following [these instructions](doc/margin-calibration-howto.md).
---
> by following [these instructions](https://github.com/labelle-org/labelle/tree/main/doc/margin-calibration-howto.md).
142c142
< Default fonts are managed via [labelle.ini](labelle.ini).
---
> Default fonts are managed via [labelle.ini](https://github.com/labelle-org/labelle/tree/main/labelle.ini).
157,158c157,158
< See [here](vendoring/README.md) for more information and
< [LICENSE](src/labelle/_vendor/matplotlib/LICENSE) for the license.
---
> See [here](https://github.com/labelle-org/labelle/tree/main/vendoring/README.md) for more information and
> [LICENSE](https://github.com/labelle-org/labelle/tree/main/src/labelle/_vendor/matplotlib/LICENSE) for the license.
161c161
< [SIL Open Font License](src/labelle/resources/fonts/LICENSE).
---
> [SIL Open Font License](https://github.com/labelle-org/labelle/tree/main/src/labelle/resources/fonts/LICENSE).
233c233
< ![Batch mode example](doc/batch-example.png)
---
> ![Batch mode example](https://raw.githubusercontent.com/labelle-org/labelle/main/doc/batch-example.png)
269c269
< ![alt](doc/Labelle_example_1.png)
---
> ![alt](https://raw.githubusercontent.com/labelle-org/labelle/main/doc/Labelle_example_1.png)
273c273
< ![alt](doc/Labelle_example_2.png)
---
> ![alt](https://raw.githubusercontent.com/labelle-org/labelle/main/doc/Labelle_example_2.png)
277c277
< ![alt](doc/Labelle_example_3.png)
---
> ![alt](https://raw.githubusercontent.com/labelle-org/labelle/main/doc/Labelle_example_3.png)
295c295
< * This software is provided as-is, without any warranty. Please see [LICENSE](LICENSE)
---
> * This software is provided as-is, without any warranty. Please see [LICENSE](https://github.com/labelle-org/labelle/tree/main/LICENSE)
303a304
> 
```