### PR TITLE
Explicitly specify the pytest-qt API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,8 +23,18 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        sudo apt-get install -y libegl1 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1 libdbus-1-3 libxcb-cursor0
-        /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
+        sudo apt-get update && sudo apt-get install -y \
+            libegl1 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 \
+            libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 \
+            libxcb-xinerama0 libxcb-xfixes0 x11-utils libgl1 \
+            libdbus-1-3 libxcb-cursor0
+        /sbin/start-stop-daemon --start --quiet \
+            --pidfile /tmp/custom_xvfb_99.pid \
+            --make-pidfile \
+            --background \
+            --exec /usr/bin/Xvfb \
+            -- \
+            :99 -screen 0 1920x1200x24 -ac +extension GLX
         python -m pip install --upgrade pip
         pip install tox tox-gh-actions
     - name: Test with tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ replacement = '<img src="https://raw.githubusercontent.com/labelle-org/labelle/m
 pattern = '\[(.*?)\]\(((?!https?://)\S+)\)'
 replacement = '[\1](https://github.com/labelle-org/labelle/tree/main/\g<2>)'
 
+[tool.pytest.ini_options]
+qt_api = "pyqt6"
+
 [tool.tox]
 legacy_tox_ini = """
 [tox]

--- a/src/labelle/gui/tests/test_gui.py
+++ b/src/labelle/gui/tests/test_gui.py
@@ -1,10 +1,12 @@
+from pytestqt.qtbot import QtBot
+
 from labelle.gui.gui import LabelleWindow
 from labelle.gui.q_label_widgets import (
     TextDymoLabelWidget,
 )
 
 
-def test_main_window(qtbot):
+def test_main_window(qtbot: QtBot):
     widget = LabelleWindow()
     qtbot.addWidget(widget)
 


### PR DESCRIPTION
Closes https://github.com/labelle-org/labelle/issues/87

Another potential backend is pyside6, and if both are available then pytest can become confused.