### PR TITLE
Remove pyqt6 dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "PyQRCode>=1.2.1,<2",
     "python-barcode>=0.13.1,<1",
     "pyusb",
-    "PyQt6",
     "darkdetect",
     "typer",
 ]


### PR DESCRIPTION
This is a temporary workaround so that people can use the CLI without pyqt6