### PR TITLE
Bump gh-action-pypi-publish to v1.12.2 for PyPI metadata v2.4

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -41,4 +41,4 @@ jobs:
         name: dist-files
         path: dist
     - name: Publish
-      uses: pypa/gh-action-pypi-publish@v1.12.2
+      uses: pypa/gh-action-pypi-publish@v1.12.4


### PR DESCRIPTION
Otherwise the publish step of the build fails