### PR TITLE
Add upper pin on python-barcode to prevent incompatible version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "platformdirs",
     "Pillow>=8.1.2,<11",
     "PyQRCode>=1.2.1,<2",
-    "python-barcode>=0.13.1,<1",
+    "python-barcode>=0.13.1,<0.16",
     "pyusb",
     "PyQt6",
     "darkdetect",


### PR DESCRIPTION
This implements the temporary workaround suggested in #123 by @blaisegarant.