### PR TITLE
Add DYMO LabelManager PC II

### DIFF
--- a/src/labelle/lib/constants.py
+++ b/src/labelle/lib/constants.py
@@ -36,6 +36,7 @@ UNCONFIRMED_MESSAGE = (
 )
 SUPPORTED_PRODUCTS = {
     0x0011: "DYMO LabelMANAGER PC",
+    0x001c: "DYMO LabelMANAGER PC II",
     0x0015: "LabelPoint 350",
     0x1001: "LabelManager PnP (no mode switch)",
     0x1002: "LabelManager PnP (mode switch)",


### PR DESCRIPTION
Adding this line allows for my Dymo LabelManager PC II to be found by Labelle, the debug output is: 
[DEBUG] <DEVICE ID 0922:001c on Bus 001 Address 015>
  manufacturer: Dymo
  product: DYMO LabelMANAGER PC II
  serial: 26070512345678
  configurations:
  - <CONFIGURATION 1: 100 mA>
    interfaces:
    - <INTERFACE 0: Printer>

The printer works, and I have successfully printed on 24mm tape, I'm currently working out what needs to change to print on 6, 9 and 12 mm tape:
<img width="227" height="211" alt="image" src="https://github.com/user-attachments/assets/9d5ec029-2d81-4d56-99a3-cb9e61f47a79" />
