### PR TITLE
Make Labelle compatible with python-barcode v0.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "platformdirs",
     "Pillow>=8.1.2,<11",
     "PyQRCode>=1.2.1,<2",
-    "python-barcode>=0.13.1,<0.16",
+    "python-barcode>=0.13.1",
     "pyusb",
     "PyQt6",
     "darkdetect",

--- a/src/labelle/lib/barcode_writer.py
+++ b/src/labelle/lib/barcode_writer.py
@@ -14,6 +14,10 @@ BinaryString = NewType("BinaryString", str)
 """A string that's been validated to contain only '0's and '1's."""
 
 
+def _noop() -> None:
+    pass
+
+
 def _validate_string_as_binary(s: str) -> BinaryString:
     if not all(c in ("0", "1") for c in s):
         raise ValueError("Barcode can only contain 0 and 1")
@@ -26,6 +30,15 @@ class BarcodeResult(NamedTuple):
 
 
 class SimpleBarcodeWriter(BaseWriter):
+    def __init__(self) -> None:
+        # Pass dummy values because we re-implement the `render` method anyway
+        super().__init__(
+            initialize=None,
+            paint_module=_noop,
+            paint_text=None,
+            finish=_noop,
+        )
+
     def render(self, code: List[str]) -> BarcodeResult:
         """Extract the barcode string from the code and render it into an image."""
         if len(code) != 1:

--- a/src/labelle/lib/render_engines/tests/test_render_engines.py
+++ b/src/labelle/lib/render_engines/tests/test_render_engines.py
@@ -130,9 +130,8 @@ def test_barcode_render_engine_internal_error():
     )
     with pytest.raises(BarcodeRenderError) as exc_info:
         render_engine.render(RENDER_CONTEXT)
-    assert (
-        str(exc_info.value) == "Barcode render error: IllegalCharacterError("
-        "'EAN code can only contain numbers.')"
+    assert str(exc_info.value).startswith(
+        "Barcode render error: IllegalCharacterError('EAN code can only contain numbers"
     )
 
 


### PR DESCRIPTION
In [python-barcode](https://pypi.org/project/python-barcode/) v0.16.0, the API of the BaseWriter constructor was [narrowed](https://github.com/WhyNotHugo/python-barcode/compare/v0.15.1...v0.16.0#diff-01c9de34453d29913aa28bb39e4c847e2ecf95cf81b1264c2759090f870152c9) so two of its callbacks can no longer be None (see issue #123.)

Given we override the implementation that would use those callbacks anyway, this PR passes dummy callbacks. This ensures compatibility with both pre-v0.16 and newer versions of python-barcode.

Additionally, loosen one of the assertions where the upstream wording of an error message slightly changed.

Fixes #123.

/cc @blaisegarant, @maresb