### PR TITLE
Avoid hard dependency on typing_extensions for Python >= 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "PyQt6",
     "darkdetect",
     "typer>=0.16.0",
+    "typing_extensions>=3.7.4; python_version<'3.9'",
 ]
 classifiers = [
     "Operating System :: POSIX :: Linux",

--- a/src/labelle/cli/cli.py
+++ b/src/labelle/cli/cli.py
@@ -13,7 +13,11 @@ from typing import List, NoReturn, Optional
 import typer
 from rich.console import Console
 from rich.table import Table
-from typing_extensions import Annotated
+
+if sys.version_info >= (3, 9):
+    from typing import Annotated
+else:
+    from typing_extensions import Annotated
 
 from labelle import __version__
 from labelle.lib.constants import (


### PR DESCRIPTION
## Summary

- Use a `sys.version_info` check to import `Annotated` from the standard library `typing` module (Python 3.9+), falling back to `typing_extensions` for Python 3.8.
- Explicitly declare `typing_extensions` as a dependency for Python < 3.9, since it is no longer guaranteed to be pulled in transitively by `typer`.
- This avoids a `ModuleNotFoundError` under Python 3.14 when `typing_extensions` is not installed.

Fixes #140