### PR TITLE
Add DYMO LabelManager PC II

### DIFF
--- a/src/labelle/lib/constants.py
+++ b/src/labelle/lib/constants.py
@@ -36,6 +36,7 @@ UNCONFIRMED_MESSAGE = (
 )
 SUPPORTED_PRODUCTS = {
     0x0011: "DYMO LabelMANAGER PC",
+    0x001C: "DYMO LabelMANAGER PC II",
     0x0015: "LabelPoint 350",
     0x1001: "LabelManager PnP (no mode switch)",
     0x1002: "LabelManager PnP (mode switch)",


### PR DESCRIPTION
Second attempt at submitting this diff for the DYMO LabelManager PC II

The file was formatted with ruff this time, so should pass CI.