### PR TITLE
Group and add cooldown to Dependabot GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,9 @@ updates:
   directory: /
   schedule:
     interval: monthly
+  cooldown:
+    default-days: 14
+  groups:
+    actions:
+      patterns:
+        - "*"


### PR DESCRIPTION
Update the Dependabot config for GitHub Actions to:

- **Group** all `github-actions` version updates into a single PR (via a `groups` entry matching `*`), instead of one PR per action.
- Add a **14-day cooldown** (`cooldown.default-days: 14`) before Dependabot opens update PRs, to avoid churn on freshly released versions.

```yaml
version: 2
updates:
- package-ecosystem: github-actions
  directory: /
  schedule:
    interval: monthly
  cooldown:
    default-days: 14
  groups:
    actions:
      patterns:
        - "*"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)