### PR TITLE
Add explicit least-privilege permissions to GHA workflows

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,6 +5,9 @@ on:
     types: [created]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,9 @@ on:
     branches: [master]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary

Add explicit top-level `permissions:` blocks to both GitHub Actions workflows, following the principle of least privilege. Without an explicit block, workflows inherit the repository/organization default `GITHUB_TOKEN` scopes, which can be broader than necessary.

- **`tests.yml`** — the job only checks out code and runs tox, so a `contents: read` default is sufficient.
- **`pypi-publish.yml`** — the `build` job inherits `contents: read` (needed for `actions/checkout`). The `publish` job already declares its own `permissions: id-token: write`, which replaces (rather than merges with) the top-level default — so it retains OIDC trusted-publishing access while everything else drops to none. `download-artifact` for same-run artifacts works with the default token, so no extra scope is needed.

## Test plan

- No behavioral change to job logic; only token permissions are tightened.
- Existing `tests` workflow should run unchanged on this PR.
- PyPI publishing relies only on `id-token: write`, which is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)