### PR TITLE
Require Pillow >=12.2.0 (CVE-2026-42308); support Python 3.10–3.14

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os : [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     env:
       DISPLAY: ':99.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os : [ubuntu-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
       fail-fast: false
     env:
       DISPLAY: ':99.0'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,20 +23,17 @@ dependencies = [
     "PyQt6",
     "darkdetect",
     "typer>=0.16.0",
-    "typing_extensions>=3.7.4; python_version<'3.9'",
 ]
 classifiers = [
     "Operating System :: POSIX :: Linux",
     "License :: OSI Approved :: Apache Software License",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Printing",
 ]
 dynamic = ["version", "readme"]
-requires-python = ">=3.8,<4"
+requires-python = ">=3.10,<4"
 
 [project.optional-dependencies]
 test = [
@@ -97,16 +94,12 @@ qt_api = "pyqt6"
 legacy_tox_ini = """
 [tox]
 envlist =
-  py38
-  py39
   py310
   py311
   py312
 
 [gh-actions]
 python =
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Printing",
 ]
 dynamic = ["version", "readme"]
@@ -97,12 +99,16 @@ envlist =
   py310
   py311
   py312
+  py313
+  py314
 
 [gh-actions]
 python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+    3.14: py314
 
 [testenv]
 deps =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license = "Apache-2.0"
 license-file = "LICENSE"
 dependencies = [
     "platformdirs",
-    "Pillow>=8.1.2,<11",
+    "Pillow>=12.2.0,<13",
     "PyQRCode>=1.2.1,<2",
     "python-barcode>=0.13.1",
     "pyusb",

--- a/src/labelle/cli/cli.py
+++ b/src/labelle/cli/cli.py
@@ -8,16 +8,11 @@
 import logging
 import sys
 from pathlib import Path
-from typing import List, NoReturn, Optional
+from typing import Annotated, List, NoReturn, Optional
 
 import typer
 from rich.console import Console
 from rich.table import Table
-
-if sys.version_info >= (3, 9):
-    from typing import Annotated
-else:
-    from typing_extensions import Annotated
 
 from labelle import __version__
 from labelle.lib.constants import (


### PR DESCRIPTION
## Summary

We currently pin `Pillow>=8.1.2,<11`, but there is a security advisory for Pillow `<12.2.0`: **[CVE-2026-42308](https://nvd.nist.gov/vuln/detail/CVE-2026-42308)** — an integer overflow in Pillow's font glyph position tracking that can become a buffer overflow when rendering text with a crafted font. Per the advisory the attack vector is local: it requires the application to render text with an attacker-supplied font file, and the impact is limited to denial of service in the affected process. labelle lets users point at an arbitrary local font via the `--font` option, so the relevant code path is reachable — this is not a remotely exploitable issue.

The fix requires Pillow 12.2.0, and Pillow 12.x requires Python ≥3.10. This PR therefore bumps the supported Python range to **3.10–3.14** and pins Pillow accordingly.

I audited every Pillow call site: the code already uses the modern APIs that survive into Pillow 12 (`Image.Transpose.ROTATE_270`, `font.getbbox`, `draw.textbbox`, `ImageQt` with PyQt6). None of the APIs removed in Pillow 11/12 are used, so no rendering code changes were needed.

## Commits (atomic)

1. **Drop support for end-of-life Python 3.8 and 3.9** — raise `requires-python` to `>=3.10`, drop classifiers/tox/CI entries, remove the now-dead `typing_extensions` marker and the `cli.py` `typing.Annotated` version gate.
2. **Add support for Python 3.13 and 3.14** — classifiers, tox environments, CI matrix.
3. **Require Pillow >=12.2.0 to fix CVE-2026-42308** — `Pillow>=12.2.0,<13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)