### PR TITLE
Fix tests push trigger to target main instead of master

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
 
 permissions:


### PR DESCRIPTION
## Summary

The `tests.yml` `push` trigger is configured for the `master` branch, but the repository's default branch is `main`. As a result the push-triggered run never fires — tests only run via the `pull_request` trigger.

This points the trigger at `main` so tests also run on direct pushes to the default branch.

## Test plan

- No job logic changes; only the branch name in the `on.push.branches` trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)