### PR TITLE
Infer Ruff target-version from requires-python

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,6 @@ drop = [
 line-length = 88
 extend-exclude = ["_vendor"]
 src = ["src"]
-target-version = "py38"
 
 [tool.ruff.lint]
 select = [

--- a/src/labelle/cli/cli.py
+++ b/src/labelle/cli/cli.py
@@ -8,7 +8,7 @@
 import logging
 import sys
 from pathlib import Path
-from typing import Annotated, List, NoReturn, Optional
+from typing import Annotated, NoReturn
 
 import typer
 from rich.console import Console
@@ -109,7 +109,7 @@ def list_devices() -> NoReturn:
 def default(
     ctx: typer.Context,
     version: Annotated[
-        Optional[bool],
+        bool | None,
         typer.Option(
             "--version",
             callback=version_callback,
@@ -118,7 +118,7 @@ def default(
         ),
     ] = None,
     device_pattern: Annotated[
-        Optional[List[str]],
+        list[str] | None,
         typer.Option(
             "--device",
             help=(
@@ -129,7 +129,7 @@ def default(
         ),
     ] = None,
     text: Annotated[
-        Optional[List[str]],
+        list[str] | None,
         typer.Argument(
             help="Text, each parameter gives a new line",
             rich_help_panel="Elements",
@@ -160,25 +160,25 @@ def default(
         ),
     ] = Direction.LEFT,
     sample_pattern: Annotated[
-        Optional[int],
+        int | None,
         typer.Option(help="Prints test pattern of a desired dot height [px]"),
     ] = None,
     min_length: Annotated[
-        Optional[float],
+        float | None,
         typer.Option(
             help="Minimum label length [mm], add whitespace if smaller",
             rich_help_panel="Label Dimensions",
         ),
     ] = None,
     max_length: Annotated[
-        Optional[float],
+        float | None,
         typer.Option(
             help="Maximum label length [mm], error if the label won't fit",
             rich_help_panel="Label Dimensions",
         ),
     ] = None,
     fixed_length: Annotated[
-        Optional[float],
+        float | None,
         typer.Option(
             help="Fixed label length [mm], set both minimum and maximum length",
             rich_help_panel="Label Dimensions",
@@ -189,13 +189,13 @@ def default(
         typer.Option(help="Destination of the label render"),
     ] = Output.PRINTER,
     font: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             help="User font. Overrides --style parameter", rich_help_panel="Design"
         ),
     ] = None,
     qr_content: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--qr", callback=qr_callback, help="QR code", rich_help_panel="Elements"
         ),
@@ -205,7 +205,7 @@ def default(
         typer.Option(help="Read batch commands from stdin", rich_help_panel="Elements"),
     ] = False,
     barcode_content: Annotated[
-        Optional[str],
+        str | None,
         typer.Option("--barcode", help="Barcode", rich_help_panel="Elements"),
     ] = None,
     barcode_type: Annotated[
@@ -216,13 +216,13 @@ def default(
         ),
     ] = DEFAULT_BARCODE_TYPE,
     barcode_with_text_content: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--barcode-with-text", help="Barcode with text", rich_help_panel="Elements"
         ),
     ] = None,
     picture: Annotated[
-        Optional[Path], typer.Option(help="Picture", rich_help_panel="Elements")
+        Path | None, typer.Option(help="Picture", rich_help_panel="Elements")
     ] = None,
     margin_px: Annotated[
         float,
@@ -235,7 +235,7 @@ def default(
         typer.Option(help="Scaling font factor, [0,100] [%]", rich_help_panel="Design"),
     ] = 90,
     tape_size_mm: Annotated[
-        Optional[int],
+        int | None,
         typer.Option(help="Tape size [mm]", rich_help_panel="Device Configuration"),
     ] = None,
     # Old dymoprint arguments
@@ -281,7 +281,7 @@ def default(
         ),
     ] = False,
     old_style: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "-s",
             help="DEPRECATED",
@@ -289,7 +289,7 @@ def default(
         ),
     ] = None,
     old_align: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "-a",
             help="DEPRECATED",
@@ -297,7 +297,7 @@ def default(
         ),
     ] = None,
     old_font: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "-u",
             help="DEPRECATED",
@@ -305,7 +305,7 @@ def default(
         ),
     ] = None,
     old_barcode: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "-c",
             help="DEPRECATED",
@@ -313,7 +313,7 @@ def default(
         ),
     ] = None,
     barcode_text: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "--barcode-text",
             help="DEPRECATED",
@@ -321,7 +321,7 @@ def default(
         ),
     ] = None,
     old_picture: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "-p",
             help="DEPRECATED",
@@ -329,7 +329,7 @@ def default(
         ),
     ] = None,
     old_margin: Annotated[
-        Optional[int],
+        int | None,
         typer.Option(
             "-m",
             help="DEPRECATED",
@@ -337,14 +337,14 @@ def default(
         ),
     ] = None,
     scale: Annotated[
-        Optional[float],
+        float | None,
         typer.Option(
             help="DEPRECATED",
             hidden=True,
         ),
     ] = None,
     old_tape_size: Annotated[
-        Optional[int],
+        int | None,
         typer.Option(
             "-t",
             help="DEPRECATED",
@@ -352,7 +352,7 @@ def default(
         ),
     ] = None,
     old_min_length: Annotated[
-        Optional[float],
+        float | None,
         typer.Option(
             "-l",
             help="DEPRECATED",
@@ -360,7 +360,7 @@ def default(
         ),
     ] = None,
     old_justify: Annotated[
-        Optional[str],
+        str | None,
         typer.Option(
             "-j",
             help="DEPRECATED",
@@ -368,7 +368,7 @@ def default(
         ),
     ] = None,
     test_pattern: Annotated[
-        Optional[int],
+        int | None,
         typer.Option(
             help="DEPRECATED",
             hidden=True,
@@ -504,9 +504,9 @@ def default(
         render_engines.append(PictureRenderEngine(picture))
 
     if batch:
-        accumulator: List[str] = []
+        accumulator: list[str] = []
         accumulator_type: str = "empty"
-        accumulator_options: List[str] = []
+        accumulator_options: list[str] = []
 
         def flush_all():
             nonlocal accumulator

--- a/src/labelle/gui/gui.py
+++ b/src/labelle/gui/gui.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-from typing import Optional
 
 from PIL import Image
 from PyQt6 import QtCore
@@ -26,7 +25,7 @@ LOG = logging.getLogger(__name__)
 
 
 class LabelleWindow(QWidget):
-    _label_bitmap_to_print: Optional[Image.Image]
+    _label_bitmap_to_print: Image.Image | None
     _device_manager: DeviceManager
     _dymo_labeler: DymoLabeler
     _render_context: RenderContext

--- a/src/labelle/gui/q_actions.py
+++ b/src/labelle/gui/q_actions.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 from PyQt6 import QtCore
 from PyQt6.QtCore import QSize, Qt
@@ -12,12 +11,12 @@ LOG = logging.getLogger(__name__)
 class QActions(QWidget):
     _error_label: QLabel
     _is_enabled: bool
-    _last_error: Optional[str]
+    _last_error: str | None
     _print_button: QPushButton
 
     print_label_signal = QtCore.pyqtSignal(name="printLabel")
 
-    def __init__(self, parent: Optional[QWidget] = None):
+    def __init__(self, parent: QWidget | None = None):
         super().__init__(parent)
         self._error_label = QLabel()
         self._is_enabled = False

--- a/src/labelle/gui/q_labels_list.py
+++ b/src/labelle/gui/q_labels_list.py
@@ -1,5 +1,4 @@
 import logging
-from typing import List, Optional
 
 from PIL import Image
 from PyQt6 import QtCore
@@ -74,10 +73,10 @@ class QLabelList(QListWidget):
     renderPrintPayloadSignal = QtCore.pyqtSignal(
         Image.Image, name="renderPrintPayloadSignal"
     )
-    render_context: Optional[RenderContext]
-    dymo_labeler: Optional[DymoLabeler]
+    render_context: RenderContext | None
+    dymo_labeler: DymoLabeler | None
     h_margin_mm: float
-    min_label_width_mm: Optional[float]
+    min_label_width_mm: float | None
     justify: Direction
 
     def __init__(self, parent=None):
@@ -142,7 +141,7 @@ class QLabelList(QListWidget):
 
     @property
     def _payload_render_engine(self):
-        render_engines: List[RenderEngine] = []
+        render_engines: list[RenderEngine] = []
         for i in range(self.count()):
             item = self.item(i)
             item_widget = self.itemWidget(self.item(i))
@@ -206,11 +205,11 @@ class QLabelList(QListWidget):
         """
         assert self.render_context is not None
         contextMenu = QMenu(self)
-        add_text: Optional[QAction] = contextMenu.addAction("Add Text")
-        add_qr: Optional[QAction] = contextMenu.addAction("Add QR")
-        add_barcode: Optional[QAction] = contextMenu.addAction("Add Barcode")
-        add_img: Optional[QAction] = contextMenu.addAction("Add Image")
-        delete: Optional[QAction] = contextMenu.addAction("Delete")
+        add_text: QAction | None = contextMenu.addAction("Add Text")
+        add_qr: QAction | None = contextMenu.addAction("Add QR")
+        add_barcode: QAction | None = contextMenu.addAction("Add Barcode")
+        add_img: QAction | None = contextMenu.addAction("Add Image")
+        delete: QAction | None = contextMenu.addAction("Delete")
         menu_click = contextMenu.exec(event.globalPos())
 
         if menu_click == add_text:

--- a/src/labelle/gui/q_render.py
+++ b/src/labelle/gui/q_render.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Optional
 
 from PIL import Image, ImageQt
 from PyQt6.QtGui import QPixmap
@@ -9,7 +8,7 @@ LOG = logging.getLogger(__name__)
 
 
 class QRender(QLabel):
-    def __init__(self, parent: Optional[QWidget] = None) -> None:
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
         self._init_elements()
 

--- a/src/labelle/lib/barcode_to_image.py
+++ b/src/labelle/lib/barcode_to_image.py
@@ -6,7 +6,6 @@
 # this notice are preserved.
 # === END LICENSE STATEMENT ===
 
-from typing import List, Tuple, Union
 
 from PIL import Image, ImageDraw
 
@@ -17,7 +16,7 @@ def _mm2px(mm: float, dpi: float = 25.4) -> float:
     return (mm * dpi) / 25.4
 
 
-def _list_of_runs(line: BinaryString) -> List[int]:
+def _list_of_runs(line: BinaryString) -> list[int]:
     # Pack line to list give better gfx result, otherwise in can
     # result in aliasing gaps
     # '11010111' -> [2, -1, 1, -1, 3]
@@ -43,7 +42,7 @@ def _calculate_size(
     module_height: float,
     vertical_margin: float,
     dpi: float = 25.4,
-) -> Tuple[int, int]:
+) -> tuple[int, int]:
     width = 2 * quiet_zone + modules_per_line * module_width
     height = vertical_margin * 2 + module_height
     return int(_mm2px(width, dpi)), int(_mm2px(height, dpi))
@@ -99,7 +98,7 @@ def _paint_module(
     xpos: float,
     ypos: float,
     width: float,
-    color: Union[int, str],
+    color: int | str,
     dpi: float,
     module_height: float,
     draw: ImageDraw.ImageDraw,

--- a/src/labelle/lib/barcode_writer.py
+++ b/src/labelle/lib/barcode_writer.py
@@ -6,7 +6,7 @@
 # this notice are preserved.
 # === END LICENSE STATEMENT ===
 
-from typing import List, NamedTuple, NewType
+from typing import NamedTuple, NewType
 
 from barcode.writer import BaseWriter
 
@@ -39,7 +39,7 @@ class SimpleBarcodeWriter(BaseWriter):
             finish=_noop,
         )
 
-    def render(self, code: List[str]) -> BarcodeResult:
+    def render(self, code: list[str]) -> BarcodeResult:
         """Extract the barcode string from the code and render it into an image."""
         if len(code) != 1:
             raise ValueError("Barcode expected to have only one line")

--- a/src/labelle/lib/config_file.py
+++ b/src/labelle/lib/config_file.py
@@ -3,7 +3,7 @@ import warnings
 from configparser import ConfigParser
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any
 
 from platformdirs import user_config_dir
 
@@ -34,7 +34,7 @@ def get_config() -> ConfigParser:
     return config_parser
 
 
-def get_config_section(section_name: str) -> Optional[Dict[str, Any]]:
+def get_config_section(section_name: str) -> dict[str, Any] | None:
     config = get_config()
     if section_name not in config:
         return None

--- a/src/labelle/lib/font_config.py
+++ b/src/labelle/lib/font_config.py
@@ -1,7 +1,6 @@
 import logging
 from enum import Enum
 from pathlib import Path
-from typing import Dict, List, Optional
 
 import labelle.resources.fonts
 from labelle._vendor.matplotlib import font_manager
@@ -24,7 +23,7 @@ class NoStyleFound(ValueError):
 
 _DEFAULT_FONTS_DIR = Path(labelle.resources.fonts.__file__).parent
 _DEFAULT_STYLE = "regular"
-_DEFAULT_STYLES_TO_FONT_PATH: Dict[str, Path] = {
+_DEFAULT_STYLES_TO_FONT_PATH: dict[str, Path] = {
     "regular": _DEFAULT_FONTS_DIR / "Carlito-Regular.ttf",
     "bold": _DEFAULT_FONTS_DIR / "Carlito-Bold.ttf",
     "italic": _DEFAULT_FONTS_DIR / "Carlito-Italic.ttf",
@@ -42,7 +41,7 @@ class FontStyle(str, Enum):
 DefaultFontStyle = FontStyle(_DEFAULT_STYLE)
 
 
-def _get_styles_to_font_path_lookup() -> Dict[str, Path]:
+def _get_styles_to_font_path_lookup() -> dict[str, Path]:
     """Get a lookup table for styles to font paths.
 
     The lookup table is read from the config file, if available.
@@ -55,9 +54,7 @@ def _get_styles_to_font_path_lookup() -> Dict[str, Path]:
     return styles_to_font_path
 
 
-def get_font_path(
-    font: Optional[str] = None, style: Optional[str] = _DEFAULT_STYLE
-) -> Path:
+def get_font_path(font: str | None = None, style: str | None = _DEFAULT_STYLE) -> Path:
     """Get the path to a font.
 
     The `font` argument can be either a font name or a path to a font file.
@@ -97,7 +94,7 @@ def _path_from_name(name: str) -> Path:
     return matching_fonts[0]
 
 
-def get_available_fonts() -> List[Path]:
+def get_available_fonts() -> list[Path]:
     """Get a list of available font files."""
     fonts = [f for f in _DEFAULT_FONTS_DIR.iterdir() if f.suffix == ".ttf"]
     fonts.extend(Path(f) for f in font_manager.findSystemFonts())

--- a/src/labelle/lib/render_engines/horizontally_combined.py
+++ b/src/labelle/lib/render_engines/horizontally_combined.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 from PIL import Image
 

--- a/src/labelle/lib/utils.py
+++ b/src/labelle/lib/utils.py
@@ -9,7 +9,7 @@ import contextlib
 import logging
 import math
 import sys
-from typing import Generator, List, Tuple
+from collections.abc import Generator
 
 from PIL import ImageDraw
 
@@ -19,7 +19,7 @@ from labelle.lib.logger import print_exception
 LOG = logging.getLogger(__name__)
 
 
-def scaling(pix, sc) -> List[Tuple[int, int]]:
+def scaling(pix, sc) -> list[tuple[int, int]]:
     """Scaling pixel up, input: (x,y),scale-factor."""
     return [(pix[0] + i, pix[1] + j) for i in range(sc) for j in range(sc)]
 


### PR DESCRIPTION
## Summary

Follow-up to #148. With the minimum Python now at 3.10, the Ruff `target-version` was a second place to keep in sync with `requires-python`. Ruff derives the target from `project.requires-python` when `target-version` is unset, so this PR drops the hardcoded line.

Removing it raises Ruff's inferred target from `py38` to `py310`, which enables the pyupgrade rules already in the `select` list (`UP006`/`UP035`/`UP045`/`UP007`). The resulting modernization is applied in its own commit.

## Commits (atomic)

1. **Modernize type hints to Python 3.10+ syntax** — PEP 604 unions (`X | None`) and PEP 585 builtin generics (`list[str]`), dropping the corresponding `typing` imports. Applied automatically via Ruff `--fix --unsafe-fixes`, then `ruff format`. 11 files, no manual edits.
2. **Infer Ruff target-version from requires-python** — the one-line config removal.

Splitting these keeps the mechanical churn separate from the config decision, and each commit is independently lint-clean.

## Verification

- `ruff check` and `ruff format --check` pass on all tracked sources.
- `mypy` passes (pre-commit).
- CLI smoke test against a fresh install: `labelle --version` and `labelle --help` exit 0, and typer correctly introspects the new annotations (e.g. `list[str] | None` → `TEXT`, `int | None` → `INTEGER`). The `--font` and other options render as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)