### PR TITLE
Add BARCODE-WITH-TEXT to cli --batch

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ commands are:
 * `QR`: Creates a QR code block
 * `BARCODE`: Creates a barcode block. Optional: Can be preceded by #`TYPE`,
   to generate a different barcode; default is CODE128, . e.g. `BARCODE#EAN:123456789012`
+* `BARCODE-WITH-TEXT`: Creates a barcode block with text overlaid in the barcode.
+  Optional: Can be preceded by #`TYPE`, to generate a different barcode;
+  default is CODE128, e.g. `BARCODE-WITH-TEXT:im-a-text`
 
 For instance, this input:
 

--- a/src/labelle/cli/cli.py
+++ b/src/labelle/cli/cli.py
@@ -527,6 +527,20 @@ def default(
                 render_engines.append(
                     BarcodeRenderEngine("\n".join(accumulator), barcode_type)
                 )
+            elif accumulator_type == "barcode-with-text":
+                barcode_type = (
+                    BarcodeType(accumulator_options[0].lower())
+                    if accumulator_options
+                    else DEFAULT_BARCODE_TYPE
+                )
+                render_engines.append(
+                    BarcodeWithTextRenderEngine(
+                        content="\n".join(accumulator),
+                        barcode_type=barcode_type,
+                        font_file_name=font_path,
+                        frame_width_px=frame_width_px,
+                    )
+                )
 
             accumulator = []
             accumulator_type = "empty"
@@ -558,6 +572,11 @@ def default(
             elif setting == "BARCODE":
                 flush_all()
                 accumulator_type = "barcode"
+                accumulator_options = options
+                accumulator.append(value)
+            elif setting == "BARCODE-WITH-TEXT":
+                flush_all()
+                accumulator_type = "barcode-with-text"
                 accumulator_options = options
                 accumulator.append(value)
             elif setting == "NEWLINE":


### PR DESCRIPTION
Added a `BARCODE-WITH-TEXT` option to the --batch CLI.